### PR TITLE
fix cyclic dependency issue in 2018

### DIFF
--- a/src/main/java/com/fangyuzhong/intelliJ/hadoop/options/ProjectSettings.java
+++ b/src/main/java/com/fangyuzhong/intelliJ/hadoop/options/ProjectSettings.java
@@ -43,7 +43,9 @@ public class ProjectSettings
         super(project);
         connectionSettings = new ConnectionBundleSettings(project);
         generalSettings = new GeneralProjectSettings(project);
-        if ((project.isDefault() && ApplicationManager.getApplication().isActive()) || project.isInitialized())
+
+        final boolean isDefaultProject = project.isDefault();
+        if ((isDefaultProject && ApplicationManager.getApplication().isActive()) || (!isDefaultProject && project.isInitialized()))
         {
             ProjectSettings projectSettings = ProjectSettingsManager.getSettings(project);
             Element settings = new Element("settings");


### PR DESCRIPTION
I found in version 2018, there is a class "DefaultProject" that override the method "isInitialized", cause cyclic dependency.
In 2017, isInitialized returned false if project is default project.